### PR TITLE
Adding support for scala 2.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ install:
 
 script:
   - sbt ++$TRAVIS_SCALA_VERSION test
+  - sbt ++$TRAVIS_SCALA_VERSION project docs/compile
   - sbt ++$TRAVIS_SCALA_VERSION mimaReportBinaryIssues
   - sbt ++$TRAVIS_SCALA_VERSION docs/makeMicrosite
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ language: scala
 scala:
   - 2.12.6
   - 2.11.12
+  - 2.13.0-M5
 
 before_cache:
   - find $HOME/.sbt -name "*.lock" -type f -delete

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,10 +30,16 @@ install:
 
 script:
   - sbt ++$TRAVIS_SCALA_VERSION test
-  - sbt ++$TRAVIS_SCALA_VERSION project docs/compile
-  - sbt ++$TRAVIS_SCALA_VERSION mimaReportBinaryIssues
-  - sbt ++$TRAVIS_SCALA_VERSION docs/makeMicrosite
 
 after_success:
   - test $TRAVIS_PULL_REQUEST == "false" && test $TRAVIS_BRANCH == "master" && test $TRAVIS_REPO_SLUG == "ChristopherDavenport/cats-scalacheck" && sbt ++$TRAVIS_SCALA_VERSION publish
-  - test $TRAVIS_PULL_REQUEST == "false" && test $TRAVIS_BRANCH == "master" && test $TRAVIS_REPO_SLUG == "ChristopherDavenport/cats-scalacheck" && test $TRAVIS_SCALA_VERSION == "2.12.6" && sbt docs/publishMicrosite
+
+matrix:
+  include:
+    - scala: 2.12.6
+      script:
+        - sbt ++$TRAVIS_SCALA_VERSION project docs/compile
+        - sbt ++$TRAVIS_SCALA_VERSION mimaReportBinaryIssues
+        - sbt ++$TRAVIS_SCALA_VERSION docs/makeMicrosite
+      after_success:
+        - test $TRAVIS_PULL_REQUEST == "false" && test $TRAVIS_BRANCH == "master" && test $TRAVIS_REPO_SLUG == "ChristopherDavenport/cats-scalacheck" && sbt ++$TRAVIS_SCALA_VERSION docs/publishMicrosite

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,6 @@ lazy val root = project.in(file("."))
   .aggregate(
     coreJVM,
     coreJS,
-    docs
   )
   .settings(noPublishSettings)
   .settings(commonSettings, releaseSettings)

--- a/build.sbt
+++ b/build.sbt
@@ -35,10 +35,10 @@ lazy val commonSettings = Seq(
   organization := "io.chrisdavenport",
 
   scalaVersion := "2.12.6",
-  crossScalaVersions := Seq(scalaVersion.value, "2.11.12"),
+  crossScalaVersions := Seq(scalaVersion.value, "2.11.12", "2.13.0-M5"),
 
   addCompilerPlugin("org.spire-math" % "kind-projector" % "0.9.9" cross CrossVersion.binary),
-  addCompilerPlugin("com.olegpy" %% "better-monadic-for" % "0.2.4"),
+  addCompilerPlugin("com.olegpy" %% "better-monadic-for" % "0.3.0-M4"),
 
   libraryDependencies ++= Seq(
     "org.typelevel"               %%% "cats-core"                  % catsV,


### PR DESCRIPTION
Scala 2.13.0-M5 build support was added. For this

- `bm4` plugin's version was bumped;
- `doc` subproject was made to be not part of the root one;
- doc building command was added to travis-ci config;
- travis-ci was reconfigured to run doc-related stuff only for 2.12 version.