### PR TITLE
Adding support for 2.13.0-RC1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ language: scala
 scala:
   - 2.12.8
   - 2.11.12
-  - 2.13.0-M5
+  - 2.13.0-RC1
 
 before_cache:
   - find $HOME/.sbt -name "*.lock" -type f -delete

--- a/build.sbt
+++ b/build.sbt
@@ -23,7 +23,8 @@ lazy val docs = project.in(file("docs"))
   .enablePlugins(TutPlugin)
   .dependsOn(coreJVM)
 
-val catsV = "2.0.0-M1"
+// Different versions because for unknown reason tut doesn't work with cats-2.0.0-M1 with scala 2.12
+def catsV(scalaVersion: String) = if (scalaVersion startsWith "2.13.") "2.0.0-M1" else "1.6.0"
 val scalacheckV = "1.14.0"
 
 lazy val contributors = Seq(
@@ -40,11 +41,11 @@ lazy val commonSettings = Seq(
   addCompilerPlugin("com.olegpy" %% "better-monadic-for" % "0.3.0"),
 
   libraryDependencies ++= Seq(
-    "org.typelevel"               %%% "cats-core"                  % catsV,
+    "org.typelevel"               %%% "cats-core"                  % catsV(scalaVersion.value),
     "org.scalacheck"              %%% "scalacheck"                 % scalacheckV,
 
-    "org.typelevel"               %%% "cats-laws"                  % catsV % Test,
-    "org.typelevel"               %%% "cats-testkit"               % catsV % Test
+    "org.typelevel"               %%% "cats-laws"                  % catsV(scalaVersion.value) % Test,
+    "org.typelevel"               %%% "cats-testkit"               % catsV(scalaVersion.value) % Test
   )
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -34,7 +34,7 @@ lazy val commonSettings = Seq(
   organization := "io.chrisdavenport",
 
   scalaVersion := "2.12.8",
-  crossScalaVersions := Seq(scalaVersion.value, "2.11.12", "2.13.0-M5"),
+  crossScalaVersions := Seq(scalaVersion.value, "2.11.12", "2.13.0-RC1"),
 
   addCompilerPlugin("org.spire-math" % "kind-projector" % "0.9.9" cross CrossVersion.binary),
   addCompilerPlugin("com.olegpy" %% "better-monadic-for" % "0.3.0-M4"),

--- a/build.sbt
+++ b/build.sbt
@@ -36,7 +36,7 @@ lazy val commonSettings = Seq(
   scalaVersion := "2.12.8",
   crossScalaVersions := Seq(scalaVersion.value, "2.11.12", "2.13.0-RC1"),
 
-  addCompilerPlugin("org.typelevel" % "kind-projector" % "0.10.0" cross CrossVersion.binary),
+  addCompilerPlugin("org.typelevel" %% "kind-projector" % "0.10.0"),
   addCompilerPlugin("com.olegpy" %% "better-monadic-for" % "0.3.0"),
 
   libraryDependencies ++= Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -23,7 +23,7 @@ lazy val docs = project.in(file("docs"))
   .enablePlugins(TutPlugin)
   .dependsOn(coreJVM)
 
-val catsV = "1.6.0"
+val catsV = "2.0.0-M1"
 val scalacheckV = "1.14.0"
 
 lazy val contributors = Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -36,8 +36,8 @@ lazy val commonSettings = Seq(
   scalaVersion := "2.12.8",
   crossScalaVersions := Seq(scalaVersion.value, "2.11.12", "2.13.0-RC1"),
 
-  addCompilerPlugin("org.spire-math" % "kind-projector" % "0.9.9" cross CrossVersion.binary),
-  addCompilerPlugin("com.olegpy" %% "better-monadic-for" % "0.3.0-M4"),
+  addCompilerPlugin("org.typelevel" % "kind-projector" % "0.10.0" cross CrossVersion.binary),
+  addCompilerPlugin("com.olegpy" %% "better-monadic-for" % "0.3.0"),
 
   libraryDependencies ++= Seq(
     "org.typelevel"               %%% "cats-core"                  % catsV,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
 addSbtPlugin("com.dwijnand" % "sbt-travisci" % "1.2.0")
 addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "1.0.0")
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.2")
-addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.1.5")
+addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.1.6")
 addSbtPlugin("org.lyranthe.sbt" % "partial-unification" % "1.1.2")
 addSbtPlugin("com.lucidchart" % "sbt-scalafmt" % "1.15")
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.11")


### PR DESCRIPTION
Versions of libraries and plugins are bumped.

For some unknown reason _tut_ was failing strangely with
```
java.lang.VerifyError: class scala.tools.nsc.Global overrides final method isDeveloper.()Z
```
when using cats 2.0.0-M1. Documentation generation is done using 2.12 because `github4s` library is published only for 2.12.

That's why, 2.12 and 2.11 builds are using cats 1.6.0, 2.13.0-RC1 one uses cats 2.0.0-M1.